### PR TITLE
Fix PHP 8.4 Deprecation notice

### DIFF
--- a/Model/Clockwork/DataSource/MagentoCustomerSessionDataSource.php
+++ b/Model/Clockwork/DataSource/MagentoCustomerSessionDataSource.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types=1);
+
+namespace Inpvlsa\Clockwork\Model\Clockwork\DataSource;
+
+use Clockwork\DataSource\DataSource;
+use Clockwork\Request\Request;
+use Magento\Customer\Model\Session;
+
+class MagentoCustomerSessionDataSource extends DataSource
+{
+    protected ?array $customerData = null;
+
+    public function resolve(Request $request): Request
+    {
+        if ($this->customerData !== null) {
+            $request->authenticatedUser = $this->customerData;
+        }
+
+        return $request;
+    }
+
+    public function handle(Session $session): void
+    {
+        if ($session->isLoggedIn()) {
+            $customer = $session->getCustomer();
+
+            $this->customerData = [
+                'id' => $customer->getId(),
+                'username' => $customer->getEmail(),
+                'email' => $customer->getEmail(),
+                'name' => $customer->getName(),
+            ];
+        }
+    }
+}

--- a/Model/Profiler/ClockworkProfilerDriver.php
+++ b/Model/Profiler/ClockworkProfilerDriver.php
@@ -53,7 +53,7 @@ class ClockworkProfilerDriver implements DriverInterface, OutputInterface
         Profiler::start('magento');
     }
 
-    public function start($timerId, array $tags = null): void
+    public function start($timerId, ?array $tags = null): void
     {
         if ($this->firstProfilerCall === true) {
             $this->firstProfilerCall = false;

--- a/Observer/CustomerSessionInit.php
+++ b/Observer/CustomerSessionInit.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+
+namespace Inpvlsa\Clockwork\Observer;
+
+use Inpvlsa\Clockwork\Model\Clockwork\DataSource\MagentoCustomerSessionDataSource;
+use Magento\Customer\Model\Session;
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Event\ObserverInterface;
+
+class CustomerSessionInit implements ObserverInterface
+{
+    protected MagentoCustomerSessionDataSource $customerSessionDataSource;
+
+    public function __construct(
+        MagentoCustomerSessionDataSource $customerSessionDataSource
+    ) {
+        $this->customerSessionDataSource = $customerSessionDataSource;
+    }
+
+    public function execute(Observer $observer): void
+    {
+        /** @var Session $session */
+        $session = $observer->getData('customer_session');
+        $this->customerSessionDataSource->handle($session);
+    }
+}

--- a/etc/frontend/di.xml
+++ b/etc/frontend/di.xml
@@ -41,6 +41,7 @@
                 <item name="collection" xsi:type="object">Inpvlsa\Clockwork\Model\Clockwork\DataSource\MagentoCollectionDataSource</item>
                 <item name="cache" xsi:type="object">Inpvlsa\Clockwork\Model\Clockwork\DataSource\CacheDataSource</item>
                 <item name="log" xsi:type="object">Inpvlsa\Clockwork\Model\Clockwork\DataSource\MonologDataSource</item>
+                <item name="customer" xsi:type="object">Inpvlsa\Clockwork\Model\Clockwork\DataSource\MagentoCustomerSessionDataSource</item>
             </argument>
         </arguments>
     </type>

--- a/etc/frontend/events.xml
+++ b/etc/frontend/events.xml
@@ -6,4 +6,8 @@
     <event name="controller_front_send_response_before">
         <observer name="clockwork_controller_front_send_response_before" instance="Inpvlsa\Clockwork\Observer\ControllerFrontSendResponseBefore"/>
     </event>
+
+    <event name="customer_session_init">
+        <observer name="clockwork_customer_session_init" instance="Inpvlsa\Clockwork\Observer\CustomerSessionInit"/>
+    </event>
 </config>


### PR DESCRIPTION
- Fix PHP 8.4 Deprecation notice
- Removal of incorrect tracked profiler entry
- Add customer data to request
- Emulate Profiler::start('magento') call to evade errors when Profiler called outside Plugin-interceptable code